### PR TITLE
Solution to animation malfunctions caused by navigation

### DIFF
--- a/Sources/MarqueeText/MarqueeText.swift
+++ b/Sources/MarqueeText/MarqueeText.swift
@@ -45,10 +45,8 @@ public struct MarqueeText : View {
                             .offset(x: self.animate ? 0 : stringWidth + stringHeight * 2)
                             .animation(self.animate ? animation : nullAnimation, value: self.animate)
                             .onAppear {
-                                Task.init {
-                                    DispatchQueue.main.async {
-                                        self.animate = geo.size.width < stringWidth
-                                    }
+                                DispatchQueue.main.async {
+                                    self.animate = geo.size.width < stringWidth
                                 }
                             }
                             .fixedSize(horizontal: true, vertical: false)

--- a/Sources/MarqueeText/MarqueeText.swift
+++ b/Sources/MarqueeText/MarqueeText.swift
@@ -19,6 +19,9 @@ public struct MarqueeText : View {
             .delay(startDelay)
             .repeatForever(autoreverses: false)
         
+        let nullAnimation = Animation
+            .linear(duration: 0)
+        
         return ZStack {
             GeometryReader { geo in
                 if stringWidth > geo.size.width { // don't use self.animate as conditional here
@@ -27,10 +30,9 @@ public struct MarqueeText : View {
                             .lineLimit(1)
                             .font(.init(font))
                             .offset(x: self.animate ? -stringWidth - stringHeight * 2 : 0)
-                            .animation(self.animate ? animation : nil, value: self.animate)
+                            .animation(self.animate ? animation : nullAnimation, value: self.animate)
                             .onAppear {
-                                Task.init {
-                                    try await Task.sleep(nanoseconds: 500_000_000)
+                                DispatchQueue.main.async {
                                     self.animate = geo.size.width < stringWidth
                                 }
                             }
@@ -41,11 +43,12 @@ public struct MarqueeText : View {
                             .lineLimit(1)
                             .font(.init(font))
                             .offset(x: self.animate ? 0 : stringWidth + stringHeight * 2)
-                            .animation(self.animate ? animation : nil, value: self.animate)
+                            .animation(self.animate ? animation : nullAnimation, value: self.animate)
                             .onAppear {
                                 Task.init {
-                                    try await Task.sleep(nanoseconds: 500_000_000)
-                                    self.animate = geo.size.width < stringWidth
+                                    DispatchQueue.main.async {
+                                        self.animate = geo.size.width < stringWidth
+                                    }
                                 }
                             }
                             .fixedSize(horizontal: true, vertical: false)


### PR DESCRIPTION
In my app, I was using Marquee text within a list cell that navigated to another view when tapped. The list was part of a view that resided within a tab of a master tab view. I discovered that upon navigating away from the view with Marquee text and coming back (e.g. switching from the tab with the Marquee text to another tab and back, clicking on the cell with Marquee text to navigate to a view and back) the animation would break. The text would not show for a few seconds and appear going faster than the intended speed, disregarding the delay when arriving back at the original position, and more. I figured that the root of the issue was the forever repeating nature of the animation -- it seemed like upon navigation, the animation wasn't canceled and thus when navigating back, it was acting upon some states that weren't intended. I did some research to figure out how to stop an animation that repeats forever and found this:

https://stackoverflow.com/questions/59133826/swiftui-stop-an-animation-that-repeats-forever

Before my edits, the animation modifier set the animation to the animation variable or to nil through a conditional:
.animation(self.animate ? animation : nil, value: self.animate)

As mentioned in the link above, setting the animation to nil doesn't cancel it so I refactored the code to include a nulling animation:
let nullAnimation = Animation.linear(duration: 0) 

And then the animation modifier would instead look like:
.animation(self.animate ? animation : nullAnimation, value: self.animate)

This solved all the problems I mentioned above. I also added the DispatchQueue.main.async to each onAppear so that the animation would start when the view is rendered fully.
