### PR TITLE
onChange - Support for iOS 13

### DIFF
--- a/Sources/MarqueeText/MarqueeText.swift
+++ b/Sources/MarqueeText/MarqueeText.swift
@@ -88,7 +88,7 @@ public struct MarqueeText : View {
 
     }
     
-    public init(text: String, font: UIFont, leftFade: CGFloat, rightFade: CGFloat, startDelay: Double, alignment: Alignment?) {
+    public init(text: String, font: UIFont, leftFade: CGFloat, rightFade: CGFloat, startDelay: Double, alignment: Alignment? = nil) {
         self.text = text
         self.font = font
         self.leftFade = leftFade

--- a/Sources/MarqueeText/MarqueeText.swift
+++ b/Sources/MarqueeText/MarqueeText.swift
@@ -52,7 +52,7 @@ public struct MarqueeText : View {
                             .fixedSize(horizontal: true, vertical: false)
                             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)
                     }
-                    .onChange(of: self.text, perform: {text in
+                    .onValueChanged(of: self.text, perform: {text in
                         self.animate = geo.size.width < stringWidth
                     })
                     
@@ -76,7 +76,7 @@ public struct MarqueeText : View {
                 } else {
                     Text(self.text)
                         .font(.init(font))
-                        .onChange(of: self.text, perform: {text in
+                        .onValueChanged(of: self.text, perform: {text in
                             self.animate = geo.size.width < stringWidth
                         })
                         .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: alignment)

--- a/Sources/MarqueeText/SwiftUI+Extension.swift
+++ b/Sources/MarqueeText/SwiftUI+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  
+//
+//  Created by Marek Zvara on 26/08/2022.
+//
+
+import Foundation
+
+import SwiftUI
+import Combine
+
+extension View {
+    /// A backwards compatible wrapper for iOS 14 `onChange`
+    @ViewBuilder func onValueChanged<T: Equatable>(of value: T, perform onChange: @escaping (T) -> Void) -> some View {
+        if #available(iOS 14.0, *) {
+            self.onChange(of: value, perform: onChange)
+        } else {
+            self.onReceive(Just(value)) { (value) in
+                onChange(value)
+            }
+        }
+    }
+}

--- a/Tests/MarqueeTextTests/MarqueeTextTests.swift
+++ b/Tests/MarqueeTextTests/MarqueeTextTests.swift
@@ -6,7 +6,7 @@ final class MarqueeTextTests: XCTestCase {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
         // results.
-        XCTAssertEqual(MarqueeText(font: UIFont.preferredFont(forTextStyle: .subheadline), leftFade: 16, rightFade: 16, startDelay: 3).text, "Hello, World!")
+        XCTAssertEqual(MarqueeText(text: "Hello, World!", font: UIFont.preferredFont(forTextStyle: .subheadline), leftFade: 16, rightFade: 16, startDelay: 3).text, "Hello, World!")
     }
 
     static var allTests = [


### PR DESCRIPTION
onChange(of:, perform: ) is available only in iOS 14+, hence the framework can't be used for iOS 13 even if it's declared in Package.swift configuration. 

I've implemented a wrapper method using onReceive for iOS 13 emulating this functionality.