### PR TITLE
Added support to limit width if string is short

### DIFF
--- a/Sources/MarqueeText/MarqueeText.swift
+++ b/Sources/MarqueeText/MarqueeText.swift
@@ -9,6 +9,7 @@ public struct MarqueeText : View {
     public var alignment: Alignment
     
     @State private var animate = false
+    var isCompact = false
     
     public var body : some View {
         let stringWidth = text.widthOfString(usingFont: font)
@@ -84,6 +85,7 @@ public struct MarqueeText : View {
             }
         }
         .frame(height: stringHeight)
+        .frame(maxWidth: isCompact ? stringWidth : nil)
         .onDisappear { self.animate = false }
 
     }
@@ -95,6 +97,14 @@ public struct MarqueeText : View {
         self.rightFade = rightFade
         self.startDelay = startDelay
         self.alignment = alignment != nil ? alignment! : .topLeading
+    }
+}
+
+extension MarqueeText {
+    public func makeCompact(_ compact: Bool = true) -> Self {
+        var view = self
+        view.isCompact = compact
+        return view
     }
 }
 


### PR DESCRIPTION
Hello.

I wrote a code to support to limit width if string is short.
This can help locating MarqueeText center if string is shorter than width of container.


You can see difference from following codes.

```
ZStack {
    MarqueeText(text: "Hello World", font: .systemFont(ofSize: 14), leftFade: 10, rightFade: 10, startDelay: 1)
        .makeCompact()
}
.frame(width: 150)
```

```
ZStack {
    MarqueeText(text: "Hello World", font: .systemFont(ofSize: 14), leftFade: 10, rightFade: 10, startDelay: 1)
}
.frame(width: 150)
```
