### PR TITLE
Fix: Update minimum iOS deployment target to 14.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,17 +6,17 @@ import PackageDescription
 let package = Package(
     name: "MarqueeText",
     platforms: [
-        SupportedPlatform.iOS(.v13),
+        SupportedPlatform.iOS(.v14),
         SupportedPlatform.macOS(.v10_15),
         SupportedPlatform.watchOS(.v7),
-        SupportedPlatform.tvOS(.v13)
+        SupportedPlatform.tvOS(.v13),
 
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "MarqueeText",
-            targets: ["MarqueeText"]),
+            targets: ["MarqueeText"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.


### PR DESCRIPTION
  Problem

  The library currently declares iOS 13.0 as the minimum supported version in Package.swift, but uses onChange(of:perform:) modifier which is only available from iOS 14.0+.

  This causes a compilation error:
  'onChange(of:perform:)' is only available in iOS 14.0 or newer

  Error Location

  The error occurs in the following code:
  .onChange(of: text) { _ in
      self.animate = false // No scrolling needed
  }

  Solution

  Updated the minimum iOS deployment target from 13.0 to 14.0 in Package.swift to match the actual API requirements.

  Changes

  - Package.swift: Changed SupportedPlatform.iOS(.v13) → SupportedPlatform.iOS(.v14)

  Testing

  - ✅ Builds successfully on iOS 14.0+
  - ✅ No breaking changes for projects already targeting iOS 14.0+

  Note

  This is a breaking change only for projects targeting iOS 13. However, since the library already uses iOS 14+ APIs, it was not actually compatible with iOS 13 before this fix.